### PR TITLE
Updating Gain Dependency

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,1 +1,1 @@
-https://github.com/Ezandora/Gain/branches/Release/
+github Ezandora/Gain


### PR DESCRIPTION
The dependency is currently outdated. Unlikely to cause issues for most users since Gain is usually already installed, so it's been able to go under the radar for a while.